### PR TITLE
Project category changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ This list should help you keep yourself up to date with the most awesome ASGI pr
 
 _Applications that expose the ASGI interface._
 
-- [Ariadne](https://github.com/mirumee/ariadne) - A Python library for implementing GraphQL servers.
-- [tartiflette-starlette](https://github.com/tartiflette/tartiflette-starlette) - ASGI support for the Tartiflette GraphQL engine.
+[Datasette](https://github.com/simonw/datasette/)
 
 ## Application frameworks
 
@@ -43,15 +42,17 @@ _Frameworks for building ASGI web applications._
 
 _Libraries for use in ASGI apps._
 
+- [Ariadne](https://github.com/mirumee/ariadne) - A Python library for implementing GraphQL servers.
 - [asgiref](https://github.com/django/asgiref) - ASGI reference implementation, including function wrappers, server base classes and a WSGI-to-ASGI adapter.
+- [Bonnette](https://github.com/erm/bonnette) - ASGI adapter for Azure Functions.
+- [Mangum](https://github.com/erm/mangum) - AWS Lambda & API Gateway support for ASGI.
+- [tartiflette-starlette](https://github.com/tartiflette/tartiflette-starlette) - ASGI support for the Tartiflette GraphQL engine.
 
 ## Middleware
 
 _General-purpose middleware to wrap around ASGI apps._
 
-- [Bonnette](https://github.com/erm/bonnette) - ASGI adapter for Azure Functions.
 - [datasette-auth-github](https://github.com/simonw/datasette-auth-github) - GitHub OAuth authentication for ASGI apps. Supports restricting to specific users or member of specific teams or organizations.
-- [Mangum](https://github.com/erm/mangum) - AWS Lambda & API Gateway support for ASGI.
 - [ProxyHeadersMiddleware](https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py) - Use `X-Forwarded-Proto` and `X-Forwarded-For` headers set by a known and trusted proxy to make `client` and `scheme` reference the connecting client (shipped with Uvicorn).
 - [Sentry ASGI](https://docs.sentry.io/platforms/python/asgi/) - Sentry integration for ASGI frameworks (part of `sentry-sdk`).
 - [Starlette middleware](https://www.starlette.io/middleware) - Middleware for CORS, HTTPS redirection, GZip compression, and more (shipped with Starlette).

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This list should help you keep yourself up to date with the most awesome ASGI pr
 
 ## Applications
 
-_Applications that expose the ASGI interface._
+_Apps and projects that make use of the ASGI interface._
 
-[Datasette](https://github.com/simonw/datasette/)
+[Datasette](https://github.com/simonw/datasette/) - A tool for exploring and publishing data, including ASGI-compatible components and plugins.
 
 ## Application frameworks
 


### PR DESCRIPTION
Refs https://github.com/florimondmanca/awesome-asgi/issues/4

I figured that Ariadne, tartiflette-starlette, Bonnette, and Mangum fit better under the "Libraries" category and left the projects that exclusively offer a middleware under "Middleware". I also added [Datasette](https://github.com/simonw/datasette/) to applications as it seems like the perfect example of an application of ASGI as opposed to a tool/framework/library used to build ASGI applications, however I'm not sure if this means the heading "Applications that expose the ASGI interface" should be changed.

Open to any suggestions.