### PR TITLE
Remove Bocadillo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ _Apps and projects that make use of the ASGI interface._
 
 _Frameworks for building ASGI web applications._
 
-- [Bocadillo](https://bocadilloproject.github.io) - Fast, scalable and real-time capable web APIs for everyone. Powered by Starlette. Supports HTTP (incl. SSE) and WebSockets.
 - [Channels](https://channels.readthedocs.io/en/latest/) - Asynchronous support for Django, and the original driving force behind the ASGI project. Supports HTTP and WebSockets with Django integration, and any protocol with ASGI-native code.
 - [FastAPI](https://github.com/tiangolo/fastapi) - A modern, high-performance web framework for building APIs with Python 3.6+ based on standard Python type hints. Powered by Starlette and Pydantic. Supports HTTP and WebSockets.
 - [Quart](https://github.com/pgjones/quart) - A Python ASGI web microframework whose API is a superset of the Flask API. Supports HTTP (incl. SSE and HTTP/2 server push) and WebSockets.


### PR DESCRIPTION
Bocadillo is now unmaintained (see https://github.com/bocadilloproject/bocadillo/issues/334), which means that IMO it shouldn't stay on this list.

Note: it was also removed from `awesome-asyncio` - see https://github.com/timofurrer/awesome-asyncio/pull/65.