### PR TITLE
Remove Bonnette

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ _Libraries for use in ASGI apps._
 
 - [Ariadne](https://github.com/mirumee/ariadne) - A Python library for implementing GraphQL servers.
 - [asgiref](https://github.com/django/asgiref) - ASGI reference implementation, including function wrappers, server base classes and a WSGI-to-ASGI adapter.
-- [Bonnette](https://github.com/erm/bonnette) - ASGI adapter for Azure Functions.
 - [HTTPX](https://www.encode.io/httpx) - Next generation HTTP client, including async support and ability to call ASGI apps directly.
 - [Mangum](https://github.com/erm/mangum) - AWS Lambda & API Gateway support for ASGI.
 - [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi) - ASGI support for the Tartiflette GraphQL engine.


### PR DESCRIPTION
I'm not actively maintaining Bonnette currently, and I think there is likely a bit more testing to do before I'd recommend its usage at this point. For these reasons it should be removed from this list.