### PR TITLE
Add python-socketio

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ _Libraries for use in ASGI apps._
 - [asgiref](https://github.com/django/asgiref) - ASGI reference implementation, including function wrappers, server base classes and a WSGI-to-ASGI adapter.
 - [HTTPX](https://www.encode.io/httpx) - Next generation HTTP client, including async support and ability to call ASGI apps directly.
 - [Mangum](https://github.com/erm/mangum) - AWS Lambda & API Gateway support for ASGI.
+- [python-socketio](https://python-socketio.readthedocs.io) - WebSocket clients and servers using Socket.IO. Includes an ASGI application wrapper.
 - [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi) - ASGI support for the Tartiflette GraphQL engine.
 
 ## Middleware


### PR DESCRIPTION
<!--
Thanks for contributing!

Please review our contributing guidelines to make sure your contribution fits:
https://github.com/florimondmanca/awesome-asgi/blob/master/CONTRIBUTING.md

To help you out, the checklist below lists some of the points covered in the guidelines.
-->

**Checklist**

- [x] This project is explicitly related to ASGI. (_Somewhat_)
- [x] The new list entry contains a project name, URL and description.
- [x] Alphabetical order is preserved across entries and sections.

**What is this project?**

<!-- Name, short description and link to the project (you can copy-paste the PR diff). -->
[python-socketio](https://python-socketio.readthedocs.io) is a library to create WebSocket clients and servers using Socket.IO in Python (at a higher-level than e.g. manipulating `WebSocket` instances in Starlette).

It is not particularly targeted at ASGI, but it contains an [`ASGIApp`](https://python-socketio.readthedocs.io/en/latest/api.html#asgiapp-class) wrapper which means it can be integrated into another ASGI app, or served standalone using an ASGI server.
Includes an ASGI application wrapper.

Basic Starlette "echo" example:

```python
import socketio
from starlette.applications import Starlette
from starlette.routing import Mount

sio = socketio.AsyncServer(async_mode="asgi")


@sio.on("message")
async def broadcast(sid: int, data: str) -> None:
    print("Message:", data)
    await sio.emit("response", data)


routes = [Mount("/sio", socketio.ASGIApp(sio))]
app = Starlette(routes=routes)
```

**Do you know about other similar projects?**
<!-- Yes / No -->
No - AFAIK `python-socketio` is the go-to async/ASGI-capable library for integrating Socket.IO with Python.

**If so, how is this one different?**
<!-- NOTE: failing to list differences does not mean this won't be accepted. We aim at listing as many relevant ASGI resources as possible. -->
/

---

_Anyone who agrees with this pull request can add a 👍._

cc @miguelgrinberg