### PR TITLE
Add opentelemetry-python ASGI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ _Packages for monitoring ASGI web applications._
 
 <!-- sort_by:name -->
 
+- [opentelemetry-python](https://opentelemetry-python.readthedocs.io/en/stable/instrumentation/asgi/asgi.html) - ASGI middleware and helpers for collecting application metrics via the (currently alpha) OpenTelemetry standard.
 - [Scout APM Starlette](https://docs.scoutapm.com/#starlette) - Scout APM integration with Starlette and Starlette-based frameworks. (Shipped with `scout-apm`.)
 - [Sentry ASGI](https://docs.sentry.io/platforms/python/asgi/) - Sentry integration for ASGI frameworks. (Shipped with `sentry-sdk`.)
 - [timing-asgi](https://github.com/steinnes/timing-asgi) - ASGI middleware to record and emit timing metrics.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ _Packages for monitoring ASGI web applications._
 
 <!-- sort_by:name -->
 
-- [opentelemetry-python](https://opentelemetry-python.readthedocs.io/en/stable/instrumentation/asgi/asgi.html) - ASGI middleware and helpers for collecting application metrics via the (currently alpha) OpenTelemetry standard.
+- [opentelemetry-python](https://opentelemetry-python.readthedocs.io/en/stable/instrumentation/asgi/asgi.html) - ASGI middleware and helpers for collecting application metrics via the (currently alpha) OpenTelemetry standard. Supports HTTP and WebSocket.
 - [Scout APM Starlette](https://docs.scoutapm.com/#starlette) - Scout APM integration with Starlette and Starlette-based frameworks. (Shipped with `scout-apm`.)
 - [Sentry ASGI](https://docs.sentry.io/platforms/python/asgi/) - Sentry integration for ASGI frameworks. (Shipped with `sentry-sdk`.)
 - [timing-asgi](https://github.com/steinnes/timing-asgi) - ASGI middleware to record and emit timing metrics.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ _Packages for monitoring ASGI web applications._
 
 <!-- sort_by:name -->
 
-- [opentelemetry-python](https://opentelemetry-python.readthedocs.io/en/stable/instrumentation/asgi/asgi.html) - ASGI middleware and helpers for collecting application metrics via the (currently alpha) OpenTelemetry standard. Supports HTTP and WebSocket.
+- [opentelemetry-python](https://opentelemetry-python.readthedocs.io/en/latest/instrumentation/asgi/asgi.html) - ASGI middleware and helpers for collecting application metrics via the (currently alpha) OpenTelemetry standard. Supports HTTP and WebSocket.
 - [Scout APM Starlette](https://docs.scoutapm.com/#starlette) - Scout APM integration with Starlette and Starlette-based frameworks. (Shipped with `scout-apm`.)
 - [Sentry ASGI](https://docs.sentry.io/platforms/python/asgi/) - Sentry integration for ASGI frameworks. (Shipped with `sentry-sdk`.)
 - [timing-asgi](https://github.com/steinnes/timing-asgi) - ASGI middleware to record and emit timing metrics.


### PR DESCRIPTION
<!--
Thanks for contributing!

Please review our contributing guidelines to make sure your contribution fits:
https://github.com/florimondmanca/awesome-asgi/blob/master/CONTRIBUTING.md

To help you out, the checklist below lists some of the points covered in the guidelines.
-->

**Checklist**

- [x] This project is explicitly related to ASGI.
- [x] The new list entry contains a project name, URL and description.

**What is this project?**

<!-- Name, short description and link to the project (you can copy-paste the PR diff). -->

https://opentelemetry-python.readthedocs.io/en/stable/instrumentation/asgi/asgi.html

OpenTelemetry is an in-the-works CNCF project for standardizing collection of telemetry metrics (via _instrumentations_) and their ingestion (via _exporters_) in a vendor-neutral way. https://opentelemetry.io/

It is supported by several vendors, such as Datadog, as well as other open source technologies (such as Prometheus).

`opentelemetry-python` ships with an ASGI middleware and some helpers to collect metrics from any ASGI apps.

**Do you know about other similar projects?**

<!-- Yes / No -->
No

**If so, how is this one different?**

<!-- NOTE: failing to list differences does not mean this won't be accepted. We aim at listing as many relevant ASGI resources as possible. -->
/

**Context**
Found out about this while investingating https://github.com/encode/httpx/issues/1264 …

---

_Anyone who agrees with this pull request can add a 👍._

