### PR TITLE
Added NGINX Unit to the Servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ _Web servers for ASGI applications._
 
 - [Daphne](http://github.com/django/daphne) - An HTTP, HTTP2 and WebSocket protocol server for ASGI, developed to power Django Channels.
 - [Hypercorn](https://pgjones.gitlab.io/hypercorn/index.html) - An ASGI server based on the sans-io hyper, h11, h2, and wsproto libraries. Supports HTTP/1, HTTP/2, WebSockets, ASGI 2.0 and ASGI 3.0. Compatible with asyncio, uvloop and trio worker types.
-- [NGINX Unit](https://unit.nginx.org) - A polyglot app server that supports ASGI 3.0 for Python.
+- [NGINX Unit](https://unit.nginx.org) - A universal web app server that supports ASGI.
 - [Uvicorn](https://www.uvicorn.org/) - A fast ASGI server based on uvloop and httptools. Supports HTTP/1 and WebSockets.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ _Web servers for ASGI applications._
 
 - [Daphne](http://github.com/django/daphne) - An HTTP, HTTP2 and WebSocket protocol server for ASGI, developed to power Django Channels.
 - [Hypercorn](https://pgjones.gitlab.io/hypercorn/index.html) - An ASGI server based on the sans-io hyper, h11, h2, and wsproto libraries. Supports HTTP/1, HTTP/2, WebSockets, ASGI 2.0 and ASGI 3.0. Compatible with asyncio, uvloop and trio worker types.
+- [NGINX Unit](https://unit.nginx.org) - A polyglot app server that supports ASGI 3.0 for Python.
 - [Uvicorn](https://www.uvicorn.org/) - A fast ASGI server based on uvloop and httptools. Supports HTTP/1 and WebSockets.
 
 ## Testing


### PR DESCRIPTION
Added NGINX Unit (https://unit.nginx.org) to the list of servers supporting the ASGI specification.

<!--
Thanks for contributing!

Please review our contributing guidelines to make sure your contribution fits:
https://github.com/florimondmanca/awesome-asgi/blob/master/CONTRIBUTING.md

To help you out, the checklist below lists some of the points covered in the guidelines.
-->

**Checklist**

- [x] This project is explicitly related to ASGI.
- [x] The new list entry contains a project name, URL and description.

**What is this project?**

[NGINX Unit](https://unit.nginx.org) - A polyglot app server that supports ASGI 3.0 for Python.

**Do you know about other similar projects?**

Yes.

**If so, how is this one different?**

Perhaps, the most notable difference is that Unit is not a Python-only app server. It's mostly written in C, dynamically configurable, and functions as a static server/proxy as well.

---

_Anyone who agrees with this pull request can add a 👍._
