### PR TITLE
Add Falcon framework (native ASGI support since version 3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ _Frameworks for building ASGI web applications._
 - [Asgineer](https://github.com/almarklein/asgineer) - A really thin ASGI web framework, which includes support for long polling, SSE and websockets.
 - [Channels](https://channels.readthedocs.io/en/latest/) - Asynchronous support for Django, and the original driving force behind the ASGI project. Supports HTTP and WebSockets with Django integration, and any protocol with ASGI-native code.
 - [Django](https://docs.djangoproject.com/en/3.0/topics/async/) - The web framework for perfectionists with deadlines. Has native ASGI support since version 3.0.
+- [Falcon](https://falconframework.org) - The minimalist REST and app backend framework for Python, with a focus on reliability, correctness, and performance at scale. Native ASGI support since version 3.0.
 - [FastAPI](https://github.com/tiangolo/fastapi) - A modern, high-performance web framework for building APIs with Python 3.6+ based on standard Python type hints. Powered by Starlette and Pydantic. Supports HTTP and WebSockets.
 - [Guillotina](https://github.com/plone/guillotina) - Full-featured ASGI-compatible REST application framework, designed for high performance and horizontally scaling solutions.
 - [Quart](https://github.com/pgjones/quart) - A Python ASGI web microframework whose API is a superset of the Flask API. Supports HTTP (incl. SSE and HTTP/2 server push) and WebSockets.


### PR DESCRIPTION
Add [Falcon framework](https://falconframework.org) ([native ASGI support since version 3.0](https://github.com/falconry/falcon/releases/tag/3.0.0)).
![falcon](https://user-images.githubusercontent.com/3430939/113701689-c1980580-96d8-11eb-81a6-d2a43cab3295.png)

**Checklist**

- [x] This project is explicitly related to ASGI.
- [x] The new list entry contains a project name, URL and description.

**What is this project?**

[Falcon framework](https://falconframework.org) is the no-nonsense, minimalist REST and app backend framework for Python developers, with a focus on reliability, correctness, and performance at scale. 

Falcon supports both WSGI and, as of version 3.0, ASGI application servers.

**Do you know about other similar projects?**

Yes, there are many web frameworks for Python :smiling_imp:

**If so, how is this one different?**

Falcon tries to do as little as possible while remaining highly effective.
* ASGI, WSGI, and WebSocket support
* Native `asyncio` support
* No reliance on magic globals for routing and state management
* Stable interfaces with an emphasis on backwards-compatibility
* Simple API modeling through centralized RESTful routing
* Highly-optimized, extensible code base
* Easy access to headers and bodies through request and response classes
* DRY request processing via middleware components and hooks
* Strict adherence to RFCs
* Idiomatic HTTP error responses
* Straightforward exception handling
* Snappy testing with WSGI/ASGI helpers and mocks
* CPython 3.5+ and PyPy 3.5+ support

---

_Anyone who agrees with this pull request can add a 👍._
