### PR TITLE
Rename: proxycore -> proxyx

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ _Toy projects, examples and gists._
 <!-- sort_by:name -->
 
 - [nanoasgi](https://github.com/qweeze/nanoasgi) - A tiny zero-dependency ASGI web framework.
-- [proxycore](https://github.com/florimondmanca/proxycore) - Proof of concept for a lightweight HTTP/1.1 proxy service built with ASGI and [HTTPCore](https://github.com/encode/httpcore).
+- [proxyx](https://github.com/florimondmanca/proxyx) - Proof of concept for a lightweight HTTP/1.1 proxy service built with ASGI and HTTPX.
 
 ### Tutorials
 


### PR DESCRIPTION
The ProxyCore repo was renamed to ProxyX as it is now based on HTTPX, rather than HTTPCore.

See https://github.com/florimondmanca/proxyx/pull/3