### PR TITLE
Add asgi-csrf

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ _Packages and components for managing the security of ASGI web applications._
 
 <!-- sort_by:name -->
 
+- [asgi-csrf](https://github.com/simonw/asgi-csrf) - ASGI middleware for protecting against CSRF attacks.
 - [CORSMiddleware](https://www.starlette.io/middleware/#corsmiddleware) - Allow cross-origin requests from browsers. (Shipped with Starlette.)
 - [CSPMiddleware](https://piccolo-api.readthedocs.io/en/latest/csp/index.html) - Tell browsers to only run Javascript from the same origin. (Shipped with Piccolo API.)
 - [CSRFMiddleware](https://piccolo-api.readthedocs.io/en/latest/csrf/index.html) - Protect against CSRF attacks when using cookies for authentication. (Shipped with Piccolo API.)


### PR DESCRIPTION
<!--
Thanks for contributing!

Please review our contributing guidelines to make sure your contribution fits:
https://github.com/florimondmanca/awesome-asgi/blob/master/CONTRIBUTING.md

To help you out, the checklist below lists some of the points covered in the guidelines.
-->

**Checklist**

- [x] This project is explicitly related to ASGI.
- [x] The new list entry contains a project name, URL and description.

**What is this project?**

<!-- Name, short description and link to the project (you can copy-paste the PR diff). -->
`asgi-csrf` is @simonw's CSRF-for-ASGI implementation. It is widely used in the Datasette ecosystem I believe: https://github.com/simonw/asgi-csrf/network/dependents

https://github.com/simonw/asgi-csrf

**Do you know about other similar projects?**

Yes - there's the `CSRFMiddleware` already listed in this list.

**If so, how is this one different?**

`asgi-csrf` is standalone, while the `CSRFMiddleware` we have is part of a wider library (Piccolo API). Makes me think we might want to put `asgi-csrf` as the lone entry later, maybe.

---

_Anyone who agrees with this pull request can add a 👍._
