### PR TITLE
Update tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,16 @@ All contributions to this list are welcome!
 **Important notes**:
 
 - In order to avoid duplicates, please search [existing pull requests](https://github.com/florimondmanca/awesome-asgi/pulls) before submitting a new one.
-- Make sure the project you'd like to add is clearly related to ASGI. General-purpose async projects can be submitted to [awesome-asyncio](https://github.com/timofurrer/awesome-asyncio) instead.
+- Make sure the project you'd like to add is clearly related to ASGI. General-purpose async projects can be submitted to [awesome-asyncio](https://github.com/timofurrer/awesome-asyncio) instead. Likewise, in general framework-specific projects should be submitted to the corresponding lists, such as [awesome-fastapi](https://github.com/mjhea0/awesome-fastapi).
 
 Edit `README.md`:
 
-- Choose one of the sections available. If no section fits your project, feel free to [add a section](#adding-a-section).
-- Add your project to the section (**keep alphabetical order**): `- [Project name](https://example.com) - A short description which ends with a period.`
-- Check your spelling and grammar. ✅
+- Choose one of the sections available. If no section fits the project, feel free to [add a section](#adding-a-section).
+- Add the project to the section (**keep alphabetical order**):
+    ```markdown
+    - [Project name](https://example.com) - A short description which ends with a period.
+    ```
+- Check spelling and grammar.
 - Remove any trailing white space, and separate all headers, paragraphs, lists and code snippets with an empty line.
 
 Once that's done, you can [submit a PR](https://github.com/florimondmanca/awesome-asgi/compare). :-)
@@ -35,4 +38,14 @@ Once that's done, you can [submit a PR](https://github.com/florimondmanca/awesom
 ## My section header
 
 _My section description._
+```
+
+## CI
+
+A CI job checks for the order of entries.
+
+To ensure entries are properly sorted locally before pushing a PR, use:
+
+```
+make format
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+check:
+	python3 tools/sortentries.py --check
+
+format:
+	python3 tools/sortentries.py

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
 steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: "3.8"
+      versionSpec: "3.10"
     displayName: "Provision Python interpreter"
-  - bash: scripts/check
+  - bash: make check
     displayName: "Run checks"

--- a/scripts/check
+++ b/scripts/check
@@ -1,3 +1,0 @@
-#!/bin/sh -ex
-
-python tools/sortentries.py --check

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,3 +1,0 @@
-#!/bin/sh -ex
-
-python tools/sortentries.py


### PR DESCRIPTION
* Use `make`
* Add info about passing CI in CONTRIBUTING.md
* Use Python 3.10 on CI
* `lint` rule becomes `format`
* Use `python3` executable for executing tools, instead of `python` (`python` may not point to Python 3 in many environments)