### PR TITLE
Add Litestar framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ _Frameworks for building ASGI web applications._
 - [Falcon](https://falconframework.org) - The minimalist REST and app backend framework for Python, with a focus on reliability, correctness, and performance at scale. Native ASGI support since version 3.0.
 - [FastAPI](https://github.com/tiangolo/fastapi) - A modern, high-performance web framework for building APIs with Python 3.6+ based on standard Python type hints. Powered by Starlette and Pydantic. Supports HTTP and WebSockets.
 - [Guillotina](https://github.com/plone/guillotina) - Full-featured ASGI-compatible REST application framework, designed for high performance and horizontally scaling solutions.
+- [Litestar](https://litestar.dev/) - A [high-performance](https://docs.litestar.dev/latest/benchmarks.html) ASGI framework, which offers [msgspec-based](https://github.com/jcrist/msgspec) message parsing, Depdency-Injection, Authentication, OpenAPI docs, and more. Supports HTTP and Websockets. Supports asyncio and trio.
 - [Pyotr](https://pyotr.readthedocs.io) - A server framework, as well as a client library, for serving and consuming OpenAPI-based Web services. Based on Starlette and [HTTPX](https://www.python-httpx.org/).
 - [Quart](https://github.com/pgjones/quart) - A Python ASGI web microframework whose API is a superset of the Flask API. Supports HTTP (incl. SSE and HTTP/2 server push) and WebSockets.
 - [Responder](https://responder.readthedocs.io/en/latest/) - A familiar HTTP Service Framework for Python, powered by Starlette.


### PR DESCRIPTION
<!--
Thanks for contributing!

Please review our contributing guidelines to make sure your contribution fits:
https://github.com/florimondmanca/awesome-asgi/blob/master/CONTRIBUTING.md

To help you out, the checklist below lists some of the points covered in the guidelines.
-->

**Checklist**

- [x] This project is explicitly related to ASGI.
- [x] The new list entry contains a project name, URL and description.

**What is this project?**

Starlite,  a light, opinionated and flexible ASGI API framework built on top of pydantic and Starlette.

https://starlite-api.github.io/starlite/
<!-- Name, short description and link to the project (you can copy-paste the PR diff). -->

**Do you know about other similar projects?**

Yes, similar to FastAPI (both Starlette + Pydantic with OpenAPI endpoints), but afaik not related in structure/code.

**If so, how is this one different?**

Starlite is more lightweight, and (in my testing) faster due to the use of orjson.

<!-- NOTE: failing to list differences does not mean this won't be accepted. We aim at listing as many relevant ASGI resources as possible. -->

---

_Anyone who agrees with this pull request can add a 👍._
