### PR TITLE
Add blacknoise to the list of utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ _Packages for use when building real-time-capable ASGI web applications._
 _Packages for use when required integrations and extra features._
 
 - [asgi-htmx](https://github.com/florimondmanca/asgi-htmx/) - HTMX integration for ASGI applications.
+- [blacknoise](https://github.com/matthiask/blacknoise) - Static file serving middleware for ASGI applications.
 
 ## Resources
 


### PR DESCRIPTION
**Checklist**

- [x] This project is explicitly related to ASGI.
- [x] The new list entry contains a project name, URL and description.

**What is this project?**

 blacknoise is an ASGI app for static file serving inspired by whitenoise.

**Do you know about other similar projects?**

https://github.com/Archmonger/ServeStatic exists, and is an ASGI- and WSGI-speaking fork of whitenoise.

**If so, how is this one different?**

blacknoise is much smaller and simpler and doesn't contain any Django-specific code. It also builds on Starlette and therefore directly profits from all improvements done to Starlette itself.

---

_Anyone who agrees with this pull request can add a 👍._
