### PR TITLE
Remove NGINX Unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ _Web servers for ASGI applications._
 - [Daphne](http://github.com/django/daphne) - An HTTP, HTTP2 and WebSocket protocol server for ASGI, developed to power Django Channels.
 - [Granian](https://github.com/emmett-framework/granian) - A high performance Rust HTTP server for Python applications supporting ASGI/3 ASGI/3, RSGI and WSGI interfaces. Currenlty implementing HTTP 1 and 2 (eventually 3), HTTPS and websockets. 
 - [Hypercorn](https://github.com/pgjones/hypercorn) - An ASGI server based on the sans-io hyper, h11, h2, and wsproto libraries. Supports HTTP/1, HTTP/2, WebSockets, ASGI 2.0 and ASGI 3.0. Compatible with asyncio, uvloop and trio worker types.
-- [NGINX Unit](https://unit.nginx.org) - A universal web app server that supports ASGI.
 - [Uvicorn](https://www.uvicorn.org/) - A fast ASGI server based on uvloop and httptools. Supports HTTP/1 and WebSockets.
 
 ## Testing


### PR DESCRIPTION
[NGINX Unit is no longer maintained](https://github.com/nginx/unit?tab=readme-ov-file#note-this-repository-has-been-archived-there-will-likely-be-no-further-development-at-this-repo-and-security-vulnerabilities-may-be-unaddressed)

Closes issue #108. 

---

_Anyone who agrees with this pull request can add a 👍._
