### PR TITLE
Add QakeAPI to Application frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ _Frameworks for building ASGI web applications._
 - [Guillotina](https://github.com/plone/guillotina) - Full-featured ASGI-compatible REST application framework, designed for high performance and horizontally scaling solutions.
 - [Litestar](https://litestar.dev/) - A [high-performance](https://docs.litestar.dev/latest/benchmarks.html) ASGI framework, which offers [msgspec-based](https://github.com/jcrist/msgspec) message parsing, Depdency-Injection, Authentication, OpenAPI docs, and more. Supports HTTP and Websockets. Supports asyncio and trio.
 - [Pyotr](https://pyotr.readthedocs.io) - A server framework, as well as a client library, for serving and consuming OpenAPI-based Web services. Based on Starlette and [HTTPX](https://www.python-httpx.org/).
+- [QakeAPI](https://github.com/Craxti/qakeapi) - Modern asynchronous web framework built from scratch using only Python standard library. Zero dependencies for core functionality. Supports HTTP and WebSockets.
 - [Quart](https://github.com/pgjones/quart) - A Python ASGI web microframework whose API is a superset of the Flask API. Supports HTTP (incl. SSE and HTTP/2 server push) and WebSockets.
 - [Responder](https://responder.readthedocs.io/en/latest/) - A familiar HTTP Service Framework for Python, powered by Starlette.
 - [Sanic](https://sanicframework.org/) - Sanic is a Python 3.6+ web server and web framework that's written to go fast. It allows the usage of the async/await syntax added in Python 3.5, which makes your code non-blocking and speedy. Supports HTTP and WebSockets.


### PR DESCRIPTION
Add QakeAPI - Modern asynchronous web framework built from scratch using only Python standard library.

**Key Features:**
- Zero dependencies for core functionality
- Full ASGI support
- Built-in authentication, CORS, rate limiting
- Automatic OpenAPI documentation
- WebSocket support

**Links:**
- GitHub: https://github.com/Craxti/qakeapi
- PyPI: https://pypi.org/project/qakeapi/